### PR TITLE
e - specify mypy version 0.991

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -13,6 +13,7 @@ exceptiongroup==1.1.0
 idna==3.4
 iniconfig==1.1.1
 mrjob==0.7.4
+mypy==0.991
 mypy-extensions==0.4.3
 packaging==22.0
 pathspec==0.10.3


### PR DESCRIPTION
This module was previously missing from `constraints.txt`.