### PR TITLE
e - remove Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7","3.8","3.9","3.10","3.11"]
+        python-version: ["3.8","3.9","3.10","3.11"]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
It reach end-of-support on 27 Jun 2023